### PR TITLE
made the sequence argument of type 'uint16_t const *'

### DIFF
--- a/usi_i2c.c
+++ b/usi_i2c.c
@@ -27,7 +27,7 @@
 #include "usi_i2c.h"
 
 // Internal state
-static uint16_t *i2c_sequence;
+static uint16_t const *i2c_sequence;
 static uint16_t i2c_sequence_length;
 static uint8_t *i2c_receive_buffer;
 static uint16_t i2c_wakeup_sr_bits;
@@ -36,7 +36,7 @@ i2c_state_type i2c_state = I2C_IDLE;
 static inline void i2c_prepare_stop();
 static inline void i2c_prepare_data_xmit_recv();
 
-void i2c_send_sequence(uint16_t *sequence, uint16_t sequence_length, uint8_t *received_data, uint16_t wakeup_sr_bits) {
+void i2c_send_sequence(uint16_t const * sequence, uint16_t sequence_length, uint8_t *received_data, uint16_t wakeup_sr_bits) {
   while(i2c_state != I2C_IDLE); // we can't start another sequence until the current one is done
   i2c_sequence = sequence;
   i2c_sequence_length = sequence_length;

--- a/usi_i2c.h
+++ b/usi_i2c.h
@@ -43,7 +43,7 @@ void i2c_init(uint16_t usi_clock_divider, uint16_t usi_clock_source);
 // performing such lengthy tasks as I2C communication inside an interrupt handler is a bad idea anyway.  wakeup_sr_bits
 // should be a bit mask of bits to clear in the SR register when the transmission is completed (to exit LPM0: LPM0_BITS
 // (CPUOFF), for LPM3: LPM3_bits (SCG1+SCG0+CPUOFF))
-void i2c_send_sequence(uint16_t *sequence, uint16_t sequence_length, uint8_t *received_data, uint16_t wakeup_sr_bits);
+void i2c_send_sequence(uint16_t const * sequence, uint16_t sequence_length, uint8_t *received_data, uint16_t wakeup_sr_bits);
 
 typedef enum i2c_state_enum {
   I2C_IDLE = 0,


### PR DESCRIPTION
I need to send an adc a static command. As it resides in flash, it has signature `uint16_t const cmd[]`. As the library doesn't write to the TX sequence buffer, there's no reason I can imagine why the sequence argument can't be of type 'uint16_t const *'

Note, I considered making it `restricted` as well, but actually having the TX and RX buffers overlap works and saves ram ;-).