### PR TITLE
Use macros to make the interrupt work on gcc and fix the inclusion of msp430.h

### DIFF
--- a/usi_i2c.c
+++ b/usi_i2c.c
@@ -22,7 +22,7 @@
   SOFTWARE.
 */
 
-#include <msp430g2412.h>
+#include <msp430.h>
 #include <stdint.h>
 #include "usi_i2c.h"
 
@@ -79,8 +79,13 @@ static inline void i2c_prepare_data_xmit_recv() {
   }
 }
 
+#ifdef __GNUC__
+__attribute__((interrupt(USI_VECTOR)))
+#else
 #pragma vector = USI_VECTOR
-__interrupt void USI_TXRX(void)
+__interrupt
+#endif
+void USI_TXRX(void)
 {
   switch(__even_in_range(i2c_state,12)) {
   case I2C_IDLE:


### PR DESCRIPTION
Here are the fixes, gcc 5.3 now compiles without warnings.